### PR TITLE
Add apidoc building to readthedocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,6 +14,8 @@ build:
       - poetry config virtualenvs.create false
     post_install:
       - poetry install -E docs
+    pre_build:
+      - poetry run sphinx-apidoc -o source/ ../spb_curate -f
 
 sphinx:
    configuration: docs/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,7 +15,7 @@ build:
     post_install:
       - poetry install -E docs
     pre_build:
-      - poetry run sphinx-apidoc -o source/ ../spb_curate -f
+      - poetry run sphinx-apidoc -o ./docs/source/ ./spb_curate/ -f
 
 sphinx:
    configuration: docs/conf.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Fix the Readthedocs build (sc-1178)
+
 ## [1.0.0b1.post1] - 2023-05-04
 
 ### Added


### PR DESCRIPTION
## Change description

Fixing the Readthedocs build to include the sphinx-api references.

## Test & Review

Have confirmed the build process is now working as expected.