### PR TITLE
Batch API call structure refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fix the Readthedocs build (sc-1178)
+- Changed batch API parameter structure (sc-2332)
 
 ## [1.0.0b1.post1] - 2023-05-04
 

--- a/spb_curate/curate/api.py
+++ b/spb_curate/curate/api.py
@@ -8,15 +8,25 @@ from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Union
 
 import requests
+
 from spb_curate import api_requestor, error, util
-from spb_curate.abstract.api.resource import (CreateResource, DeleteResource,
-                                              ModifyResource, PaginateResource)
+from spb_curate.abstract.api.resource import (
+    CreateResource,
+    DeleteResource,
+    ModifyResource,
+    PaginateResource,
+)
 from spb_curate.abstract.superb_ai_object import SuperbAIObject
-from spb_curate.curate.model.annotation_types import (AnnotationType,
-                                                      BoundingBox, Category,
-                                                      Cuboid2D, Keypoints,
-                                                      Polygon, Polyline,
-                                                      RotatedBox)
+from spb_curate.curate.model.annotation_types import (
+    AnnotationType,
+    BoundingBox,
+    Category,
+    Cuboid2D,
+    Keypoints,
+    Polygon,
+    Polyline,
+    RotatedBox,
+)
 
 FETCH_PAGE_LIMIT = 100
 UPLOAD_IMAGE_FILE_BYTES_MAX = 20000000  # 20MB


### PR DESCRIPTION
## Change description

- Changed classes and functions that use the Curate batch APIs as the specs have been modified
- Instead of uploading batch job parameters to the s3, the client now directly sends the parameters via HTTP body

## Test & Review
