### PR TITLE
Security update for requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix the Readthedocs build (sc-1178)
 
+### Fixed
+
+- Security update for requests to `>=2.31.0,<2.32.0`
+
 ## [1.0.0b1.post1] - 2023-05-04
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.7,<4.0"
-requests = "2.28.*"
+requests = ">=2.31.0,<2.32.0"
 
 # Dev
 black = { version = "*", optional = true }


### PR DESCRIPTION
## Change description

> Requests has been vulnerable to potentially leaking Proxy-Authorization headers to destination servers, specifically during redirects to an HTTPS origin.
...
> Starting in Requests v2.31.0, Requests will no longer attach this header to redirects with an HTTPS destination. This should have no negative impacts on the default behavior of the library as the proxy credentials are already properly being handled by urllib3's ProxyManager.

## Test & Review

<!--
Have the changes been tested? Please state how and the method for the reviewer to follow.
-->
Passed E2E tests.
