### PR TITLE
[DEV] Hotfix/1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1] - 2024-03-19
+
+### Fixed
+
+- Parsing logic for non-specified http response codes
+- Override default retry logic to include POST requests
+
 ## [1.2.0] - 2024-02-16
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 [project]
 description = "The official Superb AI Curate client for Python"
 name = "superb-ai-curate"
-version = "1.2.0"
+version = "1.2.1"
 
 [[project.authors]]
 name = "Superb AI"
@@ -10,7 +10,7 @@ email = "support@superb-ai.com"
 
 [tool.poetry]
 name = "superb-ai-curate"
-version = "1.2.0"
+version = "1.2.1"
 license = "MIT"
 description = "The official Superb AI Curate client for Python"
 authors = ["Superb AI <support@superb-ai.com>"]

--- a/spb_curate/superb_ai_response.py
+++ b/spb_curate/superb_ai_response.py
@@ -7,7 +7,12 @@ class SuperbAIResponse(object):
         self.code = code
         self.headers = headers
         self.body = body
-        self.data = json.loads(body, object_pairs_hook=OrderedDict) if body else None
+        try:
+            self.data = (
+                json.loads(body, object_pairs_hook=OrderedDict) if body else None
+            )
+        except json.JSONDecodeError:
+            self.data = str(body) or None
 
     @property
     def idempotency_key(self):

--- a/tests/test_api_requestor.py
+++ b/tests/test_api_requestor.py
@@ -31,7 +31,7 @@ def credentials():
         "access_key": access_key,
         "api_base": f"https://{uuid.uuid4()}.superb-ai.com",
         "headers": {
-            f"Authorization": f"Basic {base64.b64encode(f'{team_name}:{access_key}'.encode('utf-8')).decode('utf-8')}"
+            "Authorization": f"Basic {base64.b64encode(f'{team_name}:{access_key}'.encode('utf-8')).decode('utf-8')}"
         },
     }
 
@@ -156,7 +156,7 @@ class TestApiRequestor(object):
         except APIError:
             pass
         else:
-            raise Exception(f"The bad response did not raise an exception")
+            raise Exception("The bad response did not raise an exception")
 
         ok_response = requestor.interpret_response(
             rbody=ok_empty_response["rbody"],
@@ -168,7 +168,7 @@ class TestApiRequestor(object):
         assert ok_response.code == ok_empty_response["rcode"]
         assert ok_response.headers == ok_empty_response["rheaders"]
         assert ok_response.body == ok_empty_response["rbody"]
-        assert ok_response.data == None
+        assert ok_response.data is None
 
         ok_json_response = requestor.interpret_response(
             rbody=ok_json_response["rbody"],


### PR DESCRIPTION
## [1.2.1] - 2024-03-19

### Fixed

- Parsing logic for non-specified http response codes
- Override default retry logic to include POST requests


### Test

```
urllib3.exceptions.ResponseError: too many 504 error responses

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/lukecossey/projects/superb-ai-curate-python/.venv/lib/python3.8/site-packages/requests/adapters.py", line 486, in send
    resp = conn.urlopen(
  File "/Users/lukecossey/projects/superb-ai-curate-python/.venv/lib/python3.8/site-packages/urllib3/connectionpool.py", line 946, in urlopen
    return self.urlopen(
  File "/Users/lukecossey/projects/superb-ai-curate-python/.venv/lib/python3.8/site-packages/urllib3/connectionpool.py", line 946, in urlopen
    return self.urlopen(
  File "/Users/lukecossey/projects/superb-ai-curate-python/.venv/lib/python3.8/site-packages/urllib3/connectionpool.py", line 936, in urlopen
    retries = retries.increment(method, url, response=response, _pool=self)
  File "/Users/lukecossey/projects/superb-ai-curate-python/.venv/lib/python3.8/site-packages/urllib3/util/retry.py", line 515, in increment
    raise MaxRetryError(_pool, url, reason) from reason  # type: ignore[arg-type]
urllib3.exceptions.MaxRetryError: HTTPConnectionPool(host='127.0.0.1', port=5000): Max retries exceeded with url: /curate/dataset-query/datasets/ds_0123456789ABCDEFGHIKLMNOPQ/images/im_0123456789ABCDEFGHIKLMNOPQ/ (Caused by ResponseError('too many 504 error responses'))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/lukecossey/projects/superb-ai-curate-python/spb_curate/http_client.py", line 54, in _request_internal
    result = self._thread_local.session.request(
  File "/Users/lukecossey/projects/superb-ai-curate-python/.venv/lib/python3.8/site-packages/requests/sessions.py", line 589, in request
    resp = self.send(prep, **send_kwargs)
  File "/Users/lukecossey/projects/superb-ai-curate-python/.venv/lib/python3.8/site-packages/requests/sessions.py", line 703, in send
    r = adapter.send(request, **kwargs)
  File "/Users/lukecossey/projects/superb-ai-curate-python/.venv/lib/python3.8/site-packages/requests/adapters.py", line 510, in send
    raise RetryError(e, request=request)
requests.exceptions.RetryError: HTTPConnectionPool(host='127.0.0.1', port=5000): Max retries exceeded with url: /curate/dataset-query/datasets/ds_0123456789ABCDEFGHIKLMNOPQ/images/im_0123456789ABCDEFGHIKLMNOPQ/ (Caused by ResponseError('too many 504 error responses'))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "testretry.py", line 6, in <module>
    image = spb_curate.Image.fetch(
  File "/Users/lukecossey/projects/superb-ai-curate-python/spb_curate/curate/api/curate.py", line 1781, in fetch
    return super(Image, cls).fetch(
  File "/Users/lukecossey/projects/superb-ai-curate-python/spb_curate/abstract/api/resource.py", line 55, in fetch
    return cls._static_request(
  File "/Users/lukecossey/projects/superb-ai-curate-python/spb_curate/abstract/api/resource.py", line 25, in _static_request
    response, access_key = requestor.request(
  File "/Users/lukecossey/projects/superb-ai-curate-python/spb_curate/api_requestor.py", line 161, in request
    rbody, rcode, rheaders, my_access_key = self.request_raw(
  File "/Users/lukecossey/projects/superb-ai-curate-python/spb_curate/api_requestor.py", line 264, in request_raw
    rcontent, rcode, rheaders = self._client.request(
  File "/Users/lukecossey/projects/superb-ai-curate-python/spb_curate/http_client.py", line 20, in request
    return self._request_internal(
  File "/Users/lukecossey/projects/superb-ai-curate-python/spb_curate/http_client.py", line 77, in _request_internal
    self._handle_request_error(e)
  File "/Users/lukecossey/projects/superb-ai-curate-python/spb_curate/http_client.py", line 122, in _handle_request_error
    raise error.APIConnectionError(msg, should_retry=should_retry)
spb_curate.error.APIConnectionError: Unexpected error communicating with Superb AI.

(Network error: RetryError: HTTPConnectionPool(host='127.0.0.1', port=5000): Max retries exceeded with url: /curate/dataset-query/datasets/ds_0123456789ABCDEFGHIKLMNOPQ/images/im_0123456789ABCDEFGHIKLMNOPQ/ (Caused by ResponseError('too many 504 error responses')))
```