### PR TITLE
Added INFO level logs to track the local image upload progress (sc-3368)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added upload_image_directory function for Dataset class (sc-3367)
+- Added INFO level logs to track the local image upload progress (sc-3368)
 
 ### Changed
 

--- a/spb_curate/curate/api/curate.py
+++ b/spb_curate/curate/api/curate.py
@@ -1738,6 +1738,8 @@ class Image(DeleteResource, PaginateResource, ModifyResource):
                 # Run all tasks concurrently
                 await asyncio.gather(*tasks)
 
+                util.log_info(f"Uploading local images: {i + 1} of {N}")
+
                 total_transfer_size = 0
                 file_sizes = []
                 last_i = i + 1


### PR DESCRIPTION
## Change description

Added INFO level logs to track the local image upload progress (sc-3368)

## Test & Review

<img width="901" alt="image" src="https://github.com/user-attachments/assets/0a06229d-19ba-46e7-ab70-2531e4f53aa3">
