### PR TITLE
Feature/sc 3366 local upload retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Upload local images asynchronously (sc-3366)
+- Retry local image upload on failure (sc-3366)
 
 ---
 

--- a/spb_curate/error.py
+++ b/spb_curate/error.py
@@ -104,6 +104,10 @@ class NotFoundError(SuperbAIError):
     pass
 
 
+class RetryableError(SuperbAIError):
+    pass
+
+
 class TooManyRequestsError(SuperbAIError):
     """HTTP CODE: 429"""
 

--- a/spb_curate/http_client.py
+++ b/spb_curate/http_client.py
@@ -6,6 +6,15 @@ from requests.adapters import HTTPAdapter, Retry
 
 from spb_curate import error
 
+BACKOFF_FACTOR = 1
+MAX_RETRY_COUNT = 2
+STATUS_FORCE_LIST = (500, 502, 503, 504)
+STATUS_FORCE_SET = {x for x in STATUS_FORCE_LIST}
+
+
+def calculate_backoff(attempt: int, factor: int = BACKOFF_FACTOR) -> int:
+    return factor * (2 ** (attempt - 1))
+
 
 class RequestsClient(object):
     name = "requests"
@@ -34,13 +43,12 @@ class RequestsClient(object):
                     "POST",
                     "PATCH",
                 ]
-                retry_count = 2
                 retries = Retry(
-                    total=retry_count,
-                    read=retry_count,
-                    connect=retry_count,
-                    backoff_factor=1,
-                    status_forcelist=(500, 502, 503, 504),
+                    total=MAX_RETRY_COUNT,
+                    read=MAX_RETRY_COUNT,
+                    connect=MAX_RETRY_COUNT,
+                    backoff_factor=BACKOFF_FACTOR,
+                    status_forcelist=STATUS_FORCE_LIST,
                     allowed_methods=allowed_methods,
                 )
                 adapter = HTTPAdapter(max_retries=retries)


### PR DESCRIPTION
## Change description

### Changed

- Retry local image upload on failure (sc-3366)

## Test & Review

```
Traceback (most recent call last):
  File "async_upload.py", line 33, in <module>
    job_1 = dataset.add_images(
  File "**********************/spb_curate/curate/api/curate.py", line 1192, in add_images
    return Image.create_bulk(
  File "**********************/spb_curate/curate/api/curate.py", line 1768, in create_bulk
    param_images += cls.__run_upload_local_images(
  File "**********************/spb_curate/curate/api/curate.py", line 1722, in __run_upload_local_images
    return asyncio.run(async_fn)
  File "/Users/lukecossey/.pyenv/versions/3.8.12/lib/python3.8/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/Users/lukecossey/.pyenv/versions/3.8.12/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "**********************/spb_curate/curate/api/curate.py", line 1688, in __upload_local_images
    await asyncio.gather(*tasks)
  File "**********************/spb_curate/curate/api/curate.py", line 1613, in __upload_asset
    raise error.RetryableError(
spb_curate.error.RetryableError: Failed to upload after 2 attempts due to a network error: Cannot connect to host **********************.s3.amazonaws.com:443 ssl:default [nodename nor servname provided, or not known]
```