### PR TITLE
Add images to a slice when adding images to a dataset

### DIFF
--- a/.github/workflows/ci-flow.yml
+++ b/.github/workflows/ci-flow.yml
@@ -6,41 +6,40 @@ name: A workflow for superb-ai-curate
 on:
   pull_request:
     branches:
-      - main
-      - 1.*
+    - main
+    - 1.*
 
 jobs:
   test:
     name: "superb-ai-curate ci test"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-        poetry-version: ["1.2.2"]
+        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
+        poetry-version: [ "1.2.2" ]
 
     steps:
-      - uses: actions/checkout@v3
+    - uses: actions/checkout@v3
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
 
-      - name: Run poetry image
-        uses: abatilo/actions-poetry@v2
-        with:
-          poetry-version: ${{ matrix.poetry-version }}
+    - name: Run poetry image
+      uses: abatilo/actions-poetry@v2
+      with:
+        poetry-version: ${{ matrix.poetry-version }}
 
-      - name: Install package dependency
-        run: poetry install -E dev
+    - name: Install package dependency
+      run: poetry install -E dev
 
-      - name: Test superb-ai-curate
-        run: |
-          poetry run pytest --cov=spb_curate tests
-      - name: Coverage Report
-        run: |
-          poetry run coveralls --service=github
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+    - name: Test superb-ai-curate
+      run: |
+        poetry run pytest --cov=spb_curate tests
+    - name: Coverage Report
+      run: |
+        poetry run coveralls --service=github
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `slice` parameter for `Dataset.add_images()` and `Image.create_bulk()` so that users can add newly added dataset images directly to a slice (sc-3564)
+
 ---
 
 ## [1.4.1.post1] - 2024-08-20


### PR DESCRIPTION
## Change description

Added `slice` parameter for `Dataset.add_images()` and `Image.create_bulk()` so that users can add newly added dataset images directly to a slice (sc-3564)

## Test & Review

<img width="1149" alt="스크린샷 2025-03-17 오후 3 13 05" src="https://github.com/user-attachments/assets/2a7f053c-de8c-42bd-b7c6-345dc796f34f" />


<img width="989" alt="스크린샷 2025-03-17 오후 3 12 20" src="https://github.com/user-attachments/assets/4f089853-7304-4725-b560-4430023fe230" />
